### PR TITLE
[Refactor] WaitingService refactoring

### DIFF
--- a/src/main/java/org/example/catch_line/waiting/model/entity/WaitingEntity.java
+++ b/src/main/java/org/example/catch_line/waiting/model/entity/WaitingEntity.java
@@ -39,13 +39,6 @@ public class WaitingEntity extends BaseTimeEntity {
 		this.restaurant = restaurant;
 	}
 
-	@Builder
-	public WaitingEntity(int memberCount, Status status, WaitingType waitingType) {
-		this.memberCount = memberCount;
-		this.status = status;
-		this.waitingType = waitingType;
-	}
-
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(nullable = false)

--- a/src/main/java/org/example/catch_line/waiting/model/entity/WaitingEntity.java
+++ b/src/main/java/org/example/catch_line/waiting/model/entity/WaitingEntity.java
@@ -1,16 +1,26 @@
 package org.example.catch_line.waiting.model.entity;
 
-import jakarta.persistence.*;
 import org.example.catch_line.common.BaseTimeEntity;
 import org.example.catch_line.common.constant.Status;
+import org.example.catch_line.member.model.entity.MemberEntity;
+import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.example.catch_line.member.model.entity.MemberEntity;
-import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
 
 @Entity
 @NoArgsConstructor
@@ -18,6 +28,16 @@ import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
 @Setter
 @Table(name = "waiting")
 public class WaitingEntity extends BaseTimeEntity {
+
+	@Builder
+	public WaitingEntity(int memberCount, Status status, WaitingType waitingType, MemberEntity member,
+		RestaurantEntity restaurant) {
+		this.memberCount = memberCount;
+		this.status = status;
+		this.waitingType = waitingType;
+		this.member = member;
+		this.restaurant = restaurant;
+	}
 
 	@Builder
 	public WaitingEntity(int memberCount, Status status, WaitingType waitingType) {
@@ -50,6 +70,5 @@ public class WaitingEntity extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "restaurant_id")
 	private RestaurantEntity restaurant;
-
 
 }

--- a/src/main/java/org/example/catch_line/waiting/repository/WaitingRepository.java
+++ b/src/main/java/org/example/catch_line/waiting/repository/WaitingRepository.java
@@ -1,9 +1,12 @@
 package org.example.catch_line.waiting.repository;
 
+import java.util.List;
+
 import org.example.catch_line.waiting.model.entity.WaitingEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WaitingRepository extends JpaRepository<WaitingEntity, Long> {
+	List<WaitingEntity> findByMemberMemberId(Long memberId);
 }


### PR DESCRIPTION
JPA 연관관계에 맞게 WaitingService, WaitingServiceTest, WaitingRepository, WaitingEntity 수정했습니다.

1. addWaiting > 사용자 아이디와 식당 아이디를 받고 저장
2. getAllWaiting > 사용자 아이디와 같은 웨이팅만 전체 조회

## 리팩토링을 한번 더 해야할 것 같습니다.
## 리팩토링해야 할 부분들이 있는 것 같으면 리뷰달아주세요!!