### PR TITLE
[Feat] waitingRegistrationId 구현 및 리팩토링

### DIFF
--- a/src/main/java/org/example/catch_line/history/controller/HistoryController.java
+++ b/src/main/java/org/example/catch_line/history/controller/HistoryController.java
@@ -33,8 +33,8 @@ public class HistoryController {
 		HttpSession session,
 		@RequestParam(defaultValue = "SCHEDULED") Status status
 	) {
-		SessionUtils.getMemberId(session);
-		List<HistoryResponse> allHistory = historyService.getAllHistory(session,status);
+		Long memberId = SessionUtils.getMemberId(session);
+		List<HistoryResponse> allHistory = historyService.getAllHistory(memberId,status);
 		model.addAttribute("history", allHistory);
 
 		return "history/history";

--- a/src/main/java/org/example/catch_line/history/controller/HistoryController.java
+++ b/src/main/java/org/example/catch_line/history/controller/HistoryController.java
@@ -2,6 +2,7 @@ package org.example.catch_line.history.controller;
 
 import java.util.List;
 
+import org.example.catch_line.common.SessionUtils;
 import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.history.model.dto.HistoryResponse;
@@ -32,6 +33,7 @@ public class HistoryController {
 		HttpSession session,
 		@RequestParam(defaultValue = "SCHEDULED") Status status
 	) {
+		SessionUtils.getMemberId(session);
 		List<HistoryResponse> allHistory = historyService.getAllHistory(session,status);
 		model.addAttribute("history", allHistory);
 

--- a/src/main/java/org/example/catch_line/history/model/dto/HistoryResponse.java
+++ b/src/main/java/org/example/catch_line/history/model/dto/HistoryResponse.java
@@ -41,4 +41,6 @@ public class HistoryResponse {
 
 	private LocalDateTime modifiedAt;
 
+	private int waitingRegistrationId;
+
 }

--- a/src/main/java/org/example/catch_line/history/model/dto/HistoryResponse.java
+++ b/src/main/java/org/example/catch_line/history/model/dto/HistoryResponse.java
@@ -15,7 +15,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class HistoryResponse {
 

--- a/src/main/java/org/example/catch_line/history/model/dto/HistoryResponse.java
+++ b/src/main/java/org/example/catch_line/history/model/dto/HistoryResponse.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 public class HistoryResponse {

--- a/src/main/java/org/example/catch_line/history/service/HistoryService.java
+++ b/src/main/java/org/example/catch_line/history/service/HistoryService.java
@@ -7,18 +7,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.example.catch_line.common.SessionUtils;
 import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.history.model.dto.HistoryResponse;
-import org.example.catch_line.reservation.model.dto.ReservationResponse;
 import org.example.catch_line.reservation.model.entity.ReservationEntity;
 import org.example.catch_line.reservation.repository.ReservationRepository;
-import org.example.catch_line.reservation.service.ReservationService;
-import org.example.catch_line.waiting.model.dto.WaitingResponse;
 import org.example.catch_line.waiting.model.entity.WaitingEntity;
 import org.example.catch_line.waiting.repository.WaitingRepository;
-import org.example.catch_line.waiting.service.WaitingService;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpSession;
@@ -33,12 +28,12 @@ public class HistoryService {
 
 	public List<HistoryResponse> getAllHistory(HttpSession session, Status status) {
 
-		Long memberId = SessionUtils.getMemberId(session);
+		Long memberId = (Long)session.getAttribute(SessionConst.MEMBER_ID);
 
 		List<HistoryResponse> historyResponseList = new ArrayList<>();
 
-		List<WaitingEntity> allWaiting = waitingRepository.findByMemberMemberIdAndStatus(memberId,status);
-		List<ReservationEntity> allReservation = reservationRepository.findByMemberMemberIdAndStatus(memberId,status);
+		List<WaitingEntity> allWaiting = waitingRepository.findByMemberMemberIdAndStatus(memberId, status);
+		List<ReservationEntity> allReservation = reservationRepository.findByMemberMemberIdAndStatus(memberId, status);
 
 		Map<Long, List<WaitingEntity>> waitingByRestaurant = allWaiting.stream()
 			.collect(Collectors.groupingBy(waiting -> waiting.getRestaurant().getRestaurantId()));
@@ -46,7 +41,8 @@ public class HistoryService {
 		for (Map.Entry<Long, List<WaitingEntity>> entry : waitingByRestaurant.entrySet()) {
 			Long restaurantId = entry.getKey();
 			List<WaitingEntity> waitingList = entry.getValue();
-			List<WaitingEntity> sortedWaitingList = waitingRepository.findByRestaurantRestaurantIdOrderByCreatedAt(restaurantId);
+			List<WaitingEntity> sortedWaitingList = waitingRepository.findByRestaurantRestaurantIdOrderByCreatedAt(
+				restaurantId);
 			// 정렬된 대로 순서를 매김
 			waitingList.sort(Comparator.comparing(WaitingEntity::getCreatedAt));
 			for (int i = 0; i < waitingList.size(); i++) {
@@ -68,7 +64,7 @@ public class HistoryService {
 
 	}
 
-	private HistoryResponse waitingToHistoryResponse(WaitingEntity entity,int waitingRegistrationId) {
+	private HistoryResponse waitingToHistoryResponse(WaitingEntity entity, int waitingRegistrationId) {
 		return HistoryResponse.builder()
 			.restaurantId(entity.getRestaurant().getRestaurantId())
 			.waitingId(entity.getWaitingId())

--- a/src/main/java/org/example/catch_line/history/service/HistoryService.java
+++ b/src/main/java/org/example/catch_line/history/service/HistoryService.java
@@ -41,8 +41,8 @@ public class HistoryService {
 		for (Map.Entry<Long, List<WaitingEntity>> entry : waitingByRestaurant.entrySet()) {
 			Long restaurantId = entry.getKey();
 			List<WaitingEntity> waitingList = entry.getValue();
-			List<WaitingEntity> sortedWaitingList = waitingRepository.findByRestaurantRestaurantIdOrderByCreatedAt(
-				restaurantId);
+			// List<WaitingEntity> sortedWaitingList = waitingRepository.findByRestaurantRestaurantIdOrderByCreatedAt(
+			// 	restaurantId);
 			// 정렬된 대로 순서를 매김
 			waitingList.sort(Comparator.comparing(WaitingEntity::getCreatedAt));
 			for (int i = 0; i < waitingList.size(); i++) {
@@ -51,8 +51,8 @@ public class HistoryService {
 			}
 		}
 
-		Map<Long, List<ReservationEntity>> reservationByRestaurant = allReservation.stream()
-			.collect(Collectors.groupingBy(reservation -> reservation.getRestaurant().getRestaurantId()));
+		// Map<Long, List<ReservationEntity>> reservationByRestaurant = allReservation.stream()
+		// 	.collect(Collectors.groupingBy(reservation -> reservation.getRestaurant().getRestaurantId()));
 
 		for (ReservationEntity reservation : allReservation) {
 			historyResponseList.add(reservationToHistoryResponse(reservation));

--- a/src/main/java/org/example/catch_line/history/service/HistoryService.java
+++ b/src/main/java/org/example/catch_line/history/service/HistoryService.java
@@ -26,9 +26,9 @@ public class HistoryService {
 	private final WaitingRepository waitingRepository;
 	private final ReservationRepository reservationRepository;
 
-	public List<HistoryResponse> getAllHistory(HttpSession session, Status status) {
+	public List<HistoryResponse> getAllHistory(Long memberId, Status status) {
 
-		Long memberId = (Long)session.getAttribute(SessionConst.MEMBER_ID);
+
 
 		List<HistoryResponse> historyResponseList = new ArrayList<>();
 

--- a/src/main/java/org/example/catch_line/history/service/HistoryService.java
+++ b/src/main/java/org/example/catch_line/history/service/HistoryService.java
@@ -39,7 +39,7 @@ public class HistoryService {
 			.collect(Collectors.groupingBy(waiting -> waiting.getRestaurant().getRestaurantId()));
 
 		for (Map.Entry<Long, List<WaitingEntity>> entry : waitingByRestaurant.entrySet()) {
-			Long restaurantId = entry.getKey();
+			// Long restaurantId = entry.getKey();
 			List<WaitingEntity> waitingList = entry.getValue();
 			// List<WaitingEntity> sortedWaitingList = waitingRepository.findByRestaurantRestaurantIdOrderByCreatedAt(
 			// 	restaurantId);

--- a/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
+++ b/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
@@ -3,7 +3,6 @@ package org.example.catch_line.reservation.controller;
 import java.time.LocalDateTime;
 
 import org.example.catch_line.common.SessionUtils;
-import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.reservation.model.dto.ReservationRequest;
 import org.example.catch_line.reservation.model.dto.ReservationResponse;
@@ -14,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class ReservationController {
 	@GetMapping("/restaurants/{restaurantId}/reservation")
 	public String addReservationForm(
 		@PathVariable Long restaurantId
-		) {
+	) {
 
 		return "reservation/reservation";
 	}
@@ -38,21 +38,28 @@ public class ReservationController {
 		@RequestParam Integer memberCount,
 		@RequestParam LocalDateTime reservationDate,
 		Model model,
-		HttpSession session
+		HttpSession session,
+		RedirectAttributes redirectAttributes
 	) {
-		SessionUtils.getMemberId(session);
+		try {
+			SessionUtils.getMemberId(session);
 
-		ReservationRequest reservationRequest = ReservationRequest.builder()
-			.reservationDate(reservationDate)
-			.memberCount(memberCount)
-			.status(Status.SCHEDULED)
-			.build();
+			ReservationRequest reservationRequest = ReservationRequest.builder()
+				.reservationDate(reservationDate)
+				.memberCount(memberCount)
+				.status(Status.SCHEDULED)
+				.build();
 
-		ReservationResponse reservationResponse = reservationService.addReserve(restaurantId,
-			reservationRequest, session);
+			ReservationResponse reservationResponse = reservationService.addReserve(restaurantId,
+				reservationRequest, session);
 
-		model.addAttribute("reservationResponse", reservationResponse);
+			model.addAttribute("reservationResponse", reservationResponse);
 
-		return "reservation/reservation";
+			return "redirect:/history";
+		} catch (Exception e) {
+			redirectAttributes.addFlashAttribute("error", "Reservation failed: " + e.getMessage());
+			return "redirect:/restaurants/" + restaurantId + "/reservation";
+		}
 	}
 }
+

--- a/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
+++ b/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
@@ -56,7 +56,7 @@ public class ReservationController {
 			model.addAttribute("reservationResponse", reservationResponse);
 
 			return "redirect:/history";
-		} catch (Exception e) {
+		} catch (IllegalArgumentException e) {
 			redirectAttributes.addFlashAttribute("error", "Reservation failed: " + e.getMessage());
 			return "redirect:/restaurants/" + restaurantId + "/reservation";
 		}

--- a/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
+++ b/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
@@ -42,7 +42,7 @@ public class ReservationController {
 		RedirectAttributes redirectAttributes
 	) {
 		try {
-			SessionUtils.getMemberId(session);
+			Long memberId = SessionUtils.getMemberId(session);
 
 			ReservationRequest reservationRequest = ReservationRequest.builder()
 				.reservationDate(reservationDate)
@@ -51,7 +51,7 @@ public class ReservationController {
 				.build();
 
 			ReservationResponse reservationResponse = reservationService.addReserve(restaurantId,
-				reservationRequest, session);
+				reservationRequest, memberId);
 
 			model.addAttribute("reservationResponse", reservationResponse);
 

--- a/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
+++ b/src/main/java/org/example/catch_line/reservation/controller/ReservationController.java
@@ -2,6 +2,7 @@ package org.example.catch_line.reservation.controller;
 
 import java.time.LocalDateTime;
 
+import org.example.catch_line.common.SessionUtils;
 import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.reservation.model.dto.ReservationRequest;
@@ -39,6 +40,7 @@ public class ReservationController {
 		Model model,
 		HttpSession session
 	) {
+		SessionUtils.getMemberId(session);
 
 		ReservationRequest reservationRequest = ReservationRequest.builder()
 			.reservationDate(reservationDate)

--- a/src/main/java/org/example/catch_line/reservation/exception/IdException.java
+++ b/src/main/java/org/example/catch_line/reservation/exception/IdException.java
@@ -1,0 +1,7 @@
+package org.example.catch_line.reservation.exception;
+
+public class IdException extends RuntimeException{
+	public IdException() {
+		super("올바른 경로로 접속해주세요");
+	}
+}

--- a/src/main/java/org/example/catch_line/reservation/exception/ServiceTypeException.java
+++ b/src/main/java/org/example/catch_line/reservation/exception/ServiceTypeException.java
@@ -1,0 +1,8 @@
+package org.example.catch_line.reservation.exception;
+
+public class ServiceTypeException extends RuntimeException {
+
+	public ServiceTypeException() {
+		super("식당의 서비스타입이 일치하지 않습니다");
+	}
+}

--- a/src/main/java/org/example/catch_line/reservation/model/dto/ReservationRequest.java
+++ b/src/main/java/org/example/catch_line/reservation/model/dto/ReservationRequest.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class ReservationRequest {
 

--- a/src/main/java/org/example/catch_line/reservation/model/dto/ReservationResponse.java
+++ b/src/main/java/org/example/catch_line/reservation/model/dto/ReservationResponse.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class ReservationResponse {
 

--- a/src/main/java/org/example/catch_line/reservation/model/dto/ReservationResponse.java
+++ b/src/main/java/org/example/catch_line/reservation/model/dto/ReservationResponse.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 public class ReservationResponse {

--- a/src/main/java/org/example/catch_line/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/example/catch_line/reservation/repository/ReservationRepository.java
@@ -14,4 +14,6 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
 	List<ReservationEntity> findByMemberMemberId(Long memberId);
 
 	List<ReservationEntity> findByMemberMemberIdAndStatus(Long memberId, Status status);
+
+
 }

--- a/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.example.catch_line.common.SessionUtils;
+import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.member.model.entity.MemberEntity;
 import org.example.catch_line.member.repository.MemberRepository;
@@ -32,7 +33,8 @@ public class ReservationService {
 
 	public ReservationResponse addReserve(Long restaurantId, ReservationRequest reservationRequest, HttpSession session) {
 
-		Long memberId = SessionUtils.getMemberId(session);
+		Long memberId = (Long)session.getAttribute(SessionConst.MEMBER_ID);
+
 
 		MemberEntity member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("member 아이디가 틀립니다: " + memberId));

--- a/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
@@ -13,6 +13,7 @@ import org.example.catch_line.reservation.model.entity.ReservationEntity;
 import org.example.catch_line.reservation.model.mapper.ReservationResponseMapper;
 import org.example.catch_line.reservation.repository.ReservationRepository;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
+import org.example.catch_line.restaurant.model.entity.constant.ServiceType;
 import org.example.catch_line.restaurant.repository.RestaurantRepository;
 import org.springframework.stereotype.Service;
 
@@ -38,6 +39,11 @@ public class ReservationService {
 
 		RestaurantEntity restaurant = restaurantRepository.findById(restaurantId)
 			.orElseThrow(() -> new IllegalArgumentException("식당 아이디가 틀립니다: " + restaurantId));
+
+		if (restaurant.getServiceType() != ServiceType.RESERVATION) {
+			throw new IllegalArgumentException("해당 식당은 RESERVATION 타입이 아닙니다: " + restaurantId);
+		}
+
 
 		ReservationEntity reservation = ReservationEntity.builder()
 			.member(member)

--- a/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
@@ -3,11 +3,10 @@ package org.example.catch_line.reservation.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.example.catch_line.common.SessionUtils;
-import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.member.model.entity.MemberEntity;
 import org.example.catch_line.member.repository.MemberRepository;
+import org.example.catch_line.reservation.exception.IdException;
 import org.example.catch_line.reservation.model.dto.ReservationRequest;
 import org.example.catch_line.reservation.model.dto.ReservationResponse;
 import org.example.catch_line.reservation.model.entity.ReservationEntity;
@@ -16,9 +15,9 @@ import org.example.catch_line.reservation.repository.ReservationRepository;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
 import org.example.catch_line.restaurant.model.entity.constant.ServiceType;
 import org.example.catch_line.restaurant.repository.RestaurantRepository;
+import org.example.catch_line.reservation.exception.ServiceTypeException;
 import org.springframework.stereotype.Service;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -37,13 +36,13 @@ public class ReservationService {
 
 
 		MemberEntity member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("member 아이디가 틀립니다: " + memberId));
+			.orElseThrow(() -> new IdException());
 
 		RestaurantEntity restaurant = restaurantRepository.findById(restaurantId)
-			.orElseThrow(() -> new IllegalArgumentException("식당 아이디가 틀립니다: " + restaurantId));
+			.orElseThrow(() -> new IdException());
 
 		if (restaurant.getServiceType() != ServiceType.RESERVATION) {
-			throw new IllegalArgumentException("해당 식당은 RESERVATION 타입이 아닙니다: " + restaurantId);
+			throw new ServiceTypeException();
 		}
 
 

--- a/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/catch_line/reservation/service/ReservationService.java
@@ -31,9 +31,9 @@ public class ReservationService {
 	private final ReservationRepository reservationRepository;
 	private final ReservationResponseMapper reservationResponseMapper;
 
-	public ReservationResponse addReserve(Long restaurantId, ReservationRequest reservationRequest, HttpSession session) {
+	public ReservationResponse addReserve(Long restaurantId, ReservationRequest reservationRequest, Long memberId) {
 
-		Long memberId = (Long)session.getAttribute(SessionConst.MEMBER_ID);
+
 
 
 		MemberEntity member = memberRepository.findById(memberId)

--- a/src/main/java/org/example/catch_line/waiting/controller/WaitingController.java
+++ b/src/main/java/org/example/catch_line/waiting/controller/WaitingController.java
@@ -54,7 +54,7 @@ public class WaitingController {
 			model.addAttribute("waitingResponse", waitingResponse);
 
 			return "redirect:/history";
-		} catch (Exception e) {
+		} catch (IllegalArgumentException e) {
 			redirectAttributes.addFlashAttribute("error", "Waiting failed: " + e.getMessage());
 			return "redirect:/restaurants/" + restaurantId + "/waiting";
 		}

--- a/src/main/java/org/example/catch_line/waiting/controller/WaitingController.java
+++ b/src/main/java/org/example/catch_line/waiting/controller/WaitingController.java
@@ -1,6 +1,6 @@
 package org.example.catch_line.waiting.controller;
 
-import org.example.catch_line.common.constant.SessionConst;
+import org.example.catch_line.common.SessionUtils;
 import org.example.catch_line.waiting.model.dto.WaitingRequest;
 import org.example.catch_line.waiting.model.dto.WaitingResponse;
 import org.example.catch_line.waiting.model.entity.WaitingType;
@@ -29,7 +29,6 @@ public class WaitingController {
 		return "waiting/waiting";
 	}
 
-
 	@PostMapping("/restaurants/{restaurantId}/waiting")
 	public String addWaiting(
 		@PathVariable Long restaurantId,
@@ -39,8 +38,7 @@ public class WaitingController {
 		HttpSession session
 	) {
 
-
-
+		SessionUtils.getMemberId(session);
 
 		WaitingType type = "DINE_IN".equals(waitingType) ? WaitingType.DINE_IN : WaitingType.TAKE_OUT;
 
@@ -49,7 +47,7 @@ public class WaitingController {
 			.waitingType(type)
 			.build();
 
-		WaitingResponse waitingResponse = waitingService.addWaiting(restaurantId, waitingRequest,session);
+		WaitingResponse waitingResponse = waitingService.addWaiting(restaurantId, waitingRequest, session);
 
 		model.addAttribute("waitingResponse", waitingResponse);
 

--- a/src/main/java/org/example/catch_line/waiting/controller/WaitingController.java
+++ b/src/main/java/org/example/catch_line/waiting/controller/WaitingController.java
@@ -40,7 +40,7 @@ public class WaitingController {
 		RedirectAttributes redirectAttributes
 	) {
 		try {
-			SessionUtils.getMemberId(session);
+			Long memberId = SessionUtils.getMemberId(session);
 
 			WaitingType type = "DINE_IN".equals(waitingType) ? WaitingType.DINE_IN : WaitingType.TAKE_OUT;
 
@@ -49,7 +49,7 @@ public class WaitingController {
 				.waitingType(type)
 				.build();
 
-			WaitingResponse waitingResponse = waitingService.addWaiting(restaurantId, waitingRequest, session);
+			WaitingResponse waitingResponse = waitingService.addWaiting(restaurantId, waitingRequest, memberId);
 
 			model.addAttribute("waitingResponse", waitingResponse);
 

--- a/src/main/java/org/example/catch_line/waiting/model/dto/WaitingRequest.java
+++ b/src/main/java/org/example/catch_line/waiting/model/dto/WaitingRequest.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter

--- a/src/main/java/org/example/catch_line/waiting/model/dto/WaitingRequest.java
+++ b/src/main/java/org/example/catch_line/waiting/model/dto/WaitingRequest.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class WaitingRequest {
 

--- a/src/main/java/org/example/catch_line/waiting/model/dto/WaitingResponse.java
+++ b/src/main/java/org/example/catch_line/waiting/model/dto/WaitingResponse.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter

--- a/src/main/java/org/example/catch_line/waiting/model/dto/WaitingResponse.java
+++ b/src/main/java/org/example/catch_line/waiting/model/dto/WaitingResponse.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class WaitingResponse {
 

--- a/src/main/java/org/example/catch_line/waiting/repository/WaitingRepository.java
+++ b/src/main/java/org/example/catch_line/waiting/repository/WaitingRepository.java
@@ -12,4 +12,6 @@ public interface WaitingRepository extends JpaRepository<WaitingEntity, Long> {
 	List<WaitingEntity> findByMemberMemberId(Long memberId);
 
 	List<WaitingEntity> findByMemberMemberIdAndStatus(Long memberId, Status status);
+
+	List<WaitingEntity> findByRestaurantRestaurantIdOrderByCreatedAt(Long restaurantId);
 }

--- a/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
+++ b/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
@@ -9,6 +9,7 @@ import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.member.model.entity.MemberEntity;
 import org.example.catch_line.member.repository.MemberRepository;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
+import org.example.catch_line.restaurant.model.entity.constant.ServiceType;
 import org.example.catch_line.restaurant.repository.RestaurantRepository;
 import org.example.catch_line.waiting.model.dto.WaitingRequest;
 import org.example.catch_line.waiting.model.dto.WaitingResponse;
@@ -32,13 +33,18 @@ public class WaitingService {
 	private final RestaurantRepository restaurantRepository;
 
 	public WaitingResponse addWaiting(Long restaurantId, WaitingRequest waitingRequest, HttpSession session) {
-		
+
 		Long memberId = SessionUtils.getMemberId(session);
 
 		MemberEntity member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("member 아이디가 틀립니다: " + memberId));
 		RestaurantEntity restaurant = restaurantRepository.findById(restaurantId)
 			.orElseThrow(() -> new IllegalArgumentException("식당 아이디가 틀립니다: " + restaurantId));
+
+		// 서비스 타입이 WAITING이 아니면 예외를 발생시킴
+		if (restaurant.getServiceType() != ServiceType.WAITING) {
+			throw new IllegalArgumentException("해당 식당은 WAITING 타입이 아닙니다: " + restaurantId);
+		}
 
 		WaitingEntity waiting = WaitingEntity.builder()
 			.memberCount(waitingRequest.getMemberCount())
@@ -51,6 +57,7 @@ public class WaitingService {
 
 		return waitingResponseMapper.convertToResponse(savedEntity);
 	}
+
 
 	public List<WaitingResponse> getAllWaiting(Long memberId) {
 		List<WaitingEntity> waitingEntities = waitingRepository.findByMemberMemberId(memberId);

--- a/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
+++ b/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
@@ -3,13 +3,13 @@ package org.example.catch_line.waiting.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.member.model.entity.MemberEntity;
 import org.example.catch_line.member.repository.MemberRepository;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
 import org.example.catch_line.restaurant.model.entity.constant.ServiceType;
 import org.example.catch_line.restaurant.repository.RestaurantRepository;
+import org.example.catch_line.reservation.exception.ServiceTypeException;
 import org.example.catch_line.waiting.model.dto.WaitingRequest;
 import org.example.catch_line.waiting.model.dto.WaitingResponse;
 import org.example.catch_line.waiting.model.entity.WaitingEntity;
@@ -17,7 +17,6 @@ import org.example.catch_line.waiting.model.mapper.WaitingResponseMapper;
 import org.example.catch_line.waiting.repository.WaitingRepository;
 import org.springframework.stereotype.Service;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,7 +41,7 @@ public class WaitingService {
 
 		// 서비스 타입이 WAITING이 아니면 예외를 발생시킴
 		if (restaurant.getServiceType() != ServiceType.WAITING) {
-			throw new IllegalArgumentException("해당 식당은 WAITING 타입이 아닙니다: " + restaurantId);
+			throw new ServiceTypeException();
 		}
 
 		WaitingEntity waiting = WaitingEntity.builder()

--- a/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
+++ b/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
@@ -31,9 +31,9 @@ public class WaitingService {
 	private final MemberRepository memberRepository;
 	private final RestaurantRepository restaurantRepository;
 
-	public WaitingResponse addWaiting(Long restaurantId, WaitingRequest waitingRequest, HttpSession session) {
+	public WaitingResponse addWaiting(Long restaurantId, WaitingRequest waitingRequest,Long memberId) {
 
-		Long memberId = (Long)session.getAttribute(SessionConst.MEMBER_ID);
+
 
 		MemberEntity member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("member 아이디가 틀립니다: " + memberId));

--- a/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
+++ b/src/main/java/org/example/catch_line/waiting/service/WaitingService.java
@@ -3,7 +3,6 @@ package org.example.catch_line.waiting.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.example.catch_line.common.SessionUtils;
 import org.example.catch_line.common.constant.SessionConst;
 import org.example.catch_line.common.constant.Status;
 import org.example.catch_line.member.model.entity.MemberEntity;
@@ -34,7 +33,7 @@ public class WaitingService {
 
 	public WaitingResponse addWaiting(Long restaurantId, WaitingRequest waitingRequest, HttpSession session) {
 
-		Long memberId = SessionUtils.getMemberId(session);
+		Long memberId = (Long)session.getAttribute(SessionConst.MEMBER_ID);
 
 		MemberEntity member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("member 아이디가 틀립니다: " + memberId));
@@ -57,7 +56,6 @@ public class WaitingService {
 
 		return waitingResponseMapper.convertToResponse(savedEntity);
 	}
-
 
 	public List<WaitingResponse> getAllWaiting(Long memberId) {
 		List<WaitingEntity> waitingEntities = waitingRepository.findByMemberMemberId(memberId);

--- a/src/main/resources/templates/history/history.html
+++ b/src/main/resources/templates/history/history.html
@@ -29,6 +29,7 @@
             <th>Created At</th>
             <th>Modified At</th>
             <th>Waiting Type / Reservation Date</th>
+            <th>WaitingRegistrationId</th>
         </tr>
         </thead>
         <tbody>
@@ -40,6 +41,7 @@
             <td th:text="${#temporals.format(history.createdAt, 'yyyy-MM-dd HH:mm:ss')}"></td>
             <td th:text="${history.modifiedAt != null ? #temporals.format(history.modifiedAt, 'yyyy-MM-dd HH:mm:ss') : 'N/A'}"></td>
             <td th:text="${history.serviceType == T(org.example.catch_line.restaurant.model.entity.constant.ServiceType).WAITING ? history.waitingType : (history.reservationDate != null ? #temporals.format(history.reservationDate, 'yyyy-MM-dd HH:mm:ss') : 'N/A')}"></td>
+            <td th:text="${history.serviceType == T(org.example.catch_line.restaurant.model.entity.constant.ServiceType).WAITING ? history.waitingRegistrationId : 1}"></td>
         </tr>
         </tbody>
     </table>

--- a/src/main/resources/templates/reservation/reservation.html
+++ b/src/main/resources/templates/reservation/reservation.html
@@ -36,8 +36,18 @@
 <body>
 <div class="container mt-5">
     <h1 class="text-center">예약하기</h1>
-    <form th:action="@{/restaurants/{restaurantId}/reservation(restaurantId=${restaurantId})}"
-          method="post">
+
+    <!-- Error message -->
+    <div th:if="${error}" class="alert alert-danger text-center" role="alert">
+        <span th:text="${error}"></span>
+    </div>
+
+    <!-- Success message -->
+    <div th:if="${reservationResponse != null}" class="alert alert-success text-center" role="alert">
+        예약이 성공적으로 완료되었습니다!
+    </div>
+
+    <form th:action="@{/restaurants/{restaurantId}/reservation(restaurantId=${restaurantId})}" method="post">
         <div class="form-group">
             <label for="memberCount">인원 수:</label>
             <input type="number" id="memberCount" name="memberCount" class="form-control" min="1" required>
@@ -48,11 +58,6 @@
         </div>
         <button type="submit" class="btn btn-primary">예약하기</button>
     </form>
-    <div class="mt-4">
-        <p th:if="${reservationResponse != null}" class="alert alert-success">
-            예약이 성공적으로 완료되었습니다!
-        </p>
-    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/waiting/waiting.html
+++ b/src/main/resources/templates/waiting/waiting.html
@@ -28,8 +28,18 @@
 <body>
 <div class="container">
     <h1 class="text-center mb-4">Add Waiting Information</h1>
-    <form th:action="@{/restaurants/{restaurantId}/waiting(restaurantId=${restaurantId})}"
-          method="post">
+
+    <!-- Error message -->
+    <div th:if="${error}" class="alert alert-danger text-center" role="alert">
+        <span th:text="${error}"></span>
+    </div>
+
+    <!-- Success message -->
+    <div th:if="${waitingResponse != null}" class="alert alert-success text-center" role="alert">
+        웨이팅 등록이 성공적으로 완료되었습니다!
+    </div>
+
+    <form th:action="@{/restaurants/{restaurantId}/waiting(restaurantId=${restaurantId})}" method="post">
         <!-- Hidden field for memberId -->
         <input type="hidden" th:value="${memberId}" name="memberId"/>
 
@@ -52,11 +62,6 @@
             <button type="submit" class="btn btn-primary">Submit</button>
         </div>
     </form>
-    <div class="mt-4">
-        <p th:if="${waitingResponse != null}" class="alert alert-success">
-            웨이팅 등록이 성공적으로 완료되었습니다!
-        </p>
-    </div>
 </div>
 </body>
 </html>

--- a/src/test/java/org/example/catch_line/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/org/example/catch_line/reservation/service/ReservationServiceTest.java
@@ -140,7 +140,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse response = reservationService.addReserve(restaurantId2, request, session);
+		ReservationResponse response = reservationService.addReserve(restaurantId2, request, memberId);
 
 		assertThat(response).isNotNull();
 		assertThat(response.getMemberCount()).isEqualTo(4);
@@ -167,11 +167,11 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		reservationService.addReserve(restaurantId2, request1, session);
+		reservationService.addReserve(restaurantId2, request1, memberId);
 
-		reservationService.addReserve(restaurantId2, request2, session);
+		reservationService.addReserve(restaurantId2, request2, memberId);
 
-		reservationService.addReserve(restaurantId2, request3, session);
+		reservationService.addReserve(restaurantId2, request3, memberId);
 
 		List<ReservationResponse> responses = reservationService.getAllReservation(memberId);
 
@@ -187,7 +187,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse addedResponse = reservationService.addReserve(restaurantId2, request, session);
+		ReservationResponse addedResponse = reservationService.addReserve(restaurantId2, request, memberId);
 		Long id = addedResponse.getReservationId();
 
 		ReservationResponse response = reservationService.getReservationById(id);
@@ -207,7 +207,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse response = reservationService.addReserve(restaurantId2, request, session);
+		ReservationResponse response = reservationService.addReserve(restaurantId2, request, memberId);
 		Long id = response.getReservationId();
 
 		reservationService.cancelReservation(id);
@@ -225,7 +225,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse response = reservationService.addReserve(restaurantId2, request, session);
+		ReservationResponse response = reservationService.addReserve(restaurantId2, request, memberId);
 		Long id = response.getReservationId();
 
 		ReservationRequest updatedRequest = ReservationRequest.builder()

--- a/src/test/java/org/example/catch_line/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/org/example/catch_line/reservation/service/ReservationServiceTest.java
@@ -58,6 +58,8 @@ class ReservationServiceTest {
 	private Long memberId;
 	private Long restaurantId;
 
+	private Long restaurantId2;
+
 	@BeforeEach
 	void setUp() {
 
@@ -101,9 +103,21 @@ class ReservationServiceTest {
 			.serviceType(ServiceType.WAITING)
 			.build();
 
+		RestaurantCreateRequest restaurant2 = RestaurantCreateRequest.builder()
+			.description("식당 소개")
+			.name("중식집")
+			.latitude(BigDecimal.ZERO)
+			.longitude(BigDecimal.ZERO)
+			.phoneNumber("02-1234-1234")
+			.foodType(FoodType.KOREAN)
+			.serviceType(ServiceType.RESERVATION)
+			.build();
+
 		RestaurantResponse restaurant = restaurantService.createRestaurant(request1);
+		RestaurantResponse restaurant3 = restaurantService.createRestaurant(restaurant2);
 
 		restaurantId = restaurant.getRestaurantId();
+		restaurantId2 = restaurant3.getRestaurantId();
 
 		LoginRequest loginRequest = LoginRequest.builder()
 			.email("test1@example.com")
@@ -126,7 +140,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse response = reservationService.addReserve(restaurantId, request, session);
+		ReservationResponse response = reservationService.addReserve(restaurantId2, request, session);
 
 		assertThat(response).isNotNull();
 		assertThat(response.getMemberCount()).isEqualTo(4);
@@ -153,11 +167,11 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		reservationService.addReserve(restaurantId, request1, session);
+		reservationService.addReserve(restaurantId2, request1, session);
 
-		reservationService.addReserve(restaurantId, request2, session);
+		reservationService.addReserve(restaurantId2, request2, session);
 
-		reservationService.addReserve(restaurantId, request3, session);
+		reservationService.addReserve(restaurantId2, request3, session);
 
 		List<ReservationResponse> responses = reservationService.getAllReservation(memberId);
 
@@ -173,7 +187,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse addedResponse = reservationService.addReserve(restaurantId, request, session);
+		ReservationResponse addedResponse = reservationService.addReserve(restaurantId2, request, session);
 		Long id = addedResponse.getReservationId();
 
 		ReservationResponse response = reservationService.getReservationById(id);
@@ -193,7 +207,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse response = reservationService.addReserve(restaurantId, request, session);
+		ReservationResponse response = reservationService.addReserve(restaurantId2, request, session);
 		Long id = response.getReservationId();
 
 		reservationService.cancelReservation(id);
@@ -211,7 +225,7 @@ class ReservationServiceTest {
 			.status(Status.SCHEDULED)
 			.build();
 
-		ReservationResponse response = reservationService.addReserve(restaurantId, request, session);
+		ReservationResponse response = reservationService.addReserve(restaurantId2, request, session);
 		Long id = response.getReservationId();
 
 		ReservationRequest updatedRequest = ReservationRequest.builder()

--- a/src/test/java/org/example/catch_line/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/org/example/catch_line/waiting/service/WaitingServiceTest.java
@@ -116,7 +116,7 @@ class WaitingServiceTest {
 			.memberCount(4)
 			.build();
 
-		WaitingResponse response = waitingService.addWaiting(restaurantId, request, session);
+		WaitingResponse response = waitingService.addWaiting(restaurantId, request, memberId);
 
 		WaitingEntity entity = waitingRepository.findById(response.getWaitingId()).orElseThrow();
 
@@ -143,8 +143,8 @@ class WaitingServiceTest {
 			.memberCount(5)
 			.build();
 
-		waitingService.addWaiting(restaurantId, request1, session);
-		waitingService.addWaiting(restaurantId, request2, session);
+		waitingService.addWaiting(restaurantId, request1, memberId);
+		waitingService.addWaiting(restaurantId, request2, memberId);
 
 		List<WaitingResponse> responses = waitingService.getAllWaiting(memberId);
 
@@ -170,7 +170,7 @@ class WaitingServiceTest {
 			.memberCount(4)
 			.build();
 
-		WaitingResponse addedResponse = waitingService.addWaiting(restaurantId, request, session);
+		WaitingResponse addedResponse = waitingService.addWaiting(restaurantId, request, memberId);
 		Long id = addedResponse.getWaitingId();
 
 		WaitingResponse response = waitingService.getWaitingById(id);
@@ -189,7 +189,7 @@ class WaitingServiceTest {
 			.memberCount(4)
 			.build();
 
-		WaitingResponse response = waitingService.addWaiting(restaurantId, request, session);
+		WaitingResponse response = waitingService.addWaiting(restaurantId, request, memberId);
 		Long id = response.getWaitingId();
 
 		waitingService.cancelWaiting(id);


### PR DESCRIPTION
- 세션을 이용한 로그인 검증 개선: 서비스에서 memberId를 세션을 통해 가져오고, 로그인 여부를 검증하는 로직을 컨트롤러로 이동시켰습니다. 이로 인해 memberId는 컨트롤러에서 서비스로 전달되도록 변경되었습니다.

- 예약 및 대기 처리 후 페이지 이동 개선: addReservation과 addWaiting 메서드 실행 후 사용자가 바로 history페이지로 이동하도록 수정했습니다.

- DTO 클래스 수정: DTO 클래스에서 NoArgsConstructor를 제거했습니다. 이는 생성자의 기본 동작을 보다 명확히 하기 위함입니다.

- 테스트 리팩토링: reservationTest와 waitingTest 메서드를 리팩토링하여 코드의 가독성과 유지보수성을 향상시켰습니다.

- HistoryService 업데이트: HistoryService에서 waitingRegistrationId 기능을 구현하여 대기 등록 ID 처리 로직을 추가했습니다.