### PR TITLE
[Feat] 사장님 구현, 뷰 색상 통일화

### DIFF
--- a/src/main/java/org/example/catch_line/common/SessionUtils.java
+++ b/src/main/java/org/example/catch_line/common/SessionUtils.java
@@ -1,5 +1,6 @@
 package org.example.catch_line.common;
 
+import org.example.catch_line.common.constant.Role;
 import org.example.catch_line.common.constant.SessionConst;
 
 import jakarta.servlet.http.HttpSession;
@@ -12,5 +13,9 @@ public class SessionUtils {
 			throw new InvalidSessionException();
 		}
 		return memberId;
+	}
+
+	public static Role getRole(HttpSession session) {
+		return (Role) session.getAttribute(SessionConst.ROLE);
 	}
 }

--- a/src/main/java/org/example/catch_line/member/controller/OwnerController.java
+++ b/src/main/java/org/example/catch_line/member/controller/OwnerController.java
@@ -46,7 +46,7 @@ public class OwnerController {
         try {
             restaurantService.createRestaurant(request);
         } catch (InvalidPhoneNumberException e) {
-            return saveDuplicateException(e, bindingResult);
+            return invalidPhoneNumberException(e, bindingResult);
         }
 
         return "redirect:/owner";
@@ -78,7 +78,7 @@ public class OwnerController {
         return "redirect:/restaurants/" + restaurantId;
     }
 
-    private String saveDuplicateException(Exception e, BindingResult bindingResult) {
+    private String invalidPhoneNumberException(Exception e, BindingResult bindingResult) {
         bindingResult.rejectValue("phoneNumber", null, e.getMessage());
         return "owner/createRestaurant";
     }

--- a/src/main/java/org/example/catch_line/member/controller/OwnerController.java
+++ b/src/main/java/org/example/catch_line/member/controller/OwnerController.java
@@ -1,0 +1,85 @@
+package org.example.catch_line.member.controller;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.catch_line.common.SessionUtils;
+import org.example.catch_line.common.constant.Role;
+import org.example.catch_line.exception.phone.InvalidPhoneNumberException;
+import org.example.catch_line.restaurant.model.dto.RestaurantCreateRequest;
+import org.example.catch_line.restaurant.model.dto.RestaurantResponse;
+import org.example.catch_line.restaurant.model.dto.RestaurantUpdateRequest;
+import org.example.catch_line.restaurant.model.entity.constant.FoodType;
+import org.example.catch_line.restaurant.model.entity.constant.ServiceType;
+import org.example.catch_line.restaurant.service.RestaurantService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@Controller
+@RequestMapping("/owner")
+@RequiredArgsConstructor
+public class OwnerController {
+
+    private final RestaurantService restaurantService;
+
+    @GetMapping
+    public String viewOwnerPage() {
+        return "owner/owner";
+    }
+
+    @GetMapping("/restaurants")
+    public String createRestaurantForm(Model model) {
+        model.addAttribute("request", new RestaurantCreateRequest("", "", "", "", FoodType.KOREAN, ServiceType.WAITING));
+        return "owner/createRestaurant";
+    }
+
+    @PostMapping("/restaurants")
+    public String createRestaurant(@ModelAttribute("request") RestaurantCreateRequest request, BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            log.info("error = {}", bindingResult);
+            return "owner/createRestaurant";
+        }
+
+        try {
+            restaurantService.createRestaurant(request);
+        } catch (InvalidPhoneNumberException e) {
+            return saveDuplicateException(e, bindingResult);
+        }
+
+        return "redirect:/owner";
+    }
+
+    @GetMapping("/restaurants/list")
+    public String showRestaurantListPage(HttpSession session) {
+        Long memberId = SessionUtils.getMemberId(session);
+        Role role = SessionUtils.getRole(session);
+
+        return "owner/restaurantList";
+    }
+
+    @GetMapping("/restaurants/{restaurantId}")
+    public String updateRestaurantForm(@PathVariable Long restaurantId, Model model) {
+        RestaurantResponse restaurant = restaurantService.findRestaurant(restaurantId);
+        model.addAttribute("restaurant", restaurant);
+        return "owner/updateRestaurant";
+    }
+
+    @PostMapping("/restaurants/{restaurantId}")
+    public String updateRestaurant(@PathVariable Long restaurantId, @ModelAttribute("restaurant") RestaurantUpdateRequest request, BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            return "owner/updateRestaurant";
+        }
+
+        restaurantService.updateRestaurant(restaurantId, request);
+
+        return "redirect:/restaurants/" + restaurantId;
+    }
+
+    private String saveDuplicateException(Exception e, BindingResult bindingResult) {
+        bindingResult.rejectValue("phoneNumber", null, e.getMessage());
+        return "owner/createRestaurant";
+    }
+}

--- a/src/main/java/org/example/catch_line/menu/service/MenuService.java
+++ b/src/main/java/org/example/catch_line/menu/service/MenuService.java
@@ -7,7 +7,7 @@ import org.example.catch_line.menu.model.entity.MenuEntity;
 import org.example.catch_line.menu.model.mapper.MenuMapper;
 import org.example.catch_line.menu.repository.MenuRepository;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
-import org.example.catch_line.restaurant.validate.RestaurantValidator;
+import org.example.catch_line.restaurant.validation.RestaurantValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/example/catch_line/restaurant/model/dto/RestaurantCreateRequest.java
+++ b/src/main/java/org/example/catch_line/restaurant/model/dto/RestaurantCreateRequest.java
@@ -19,14 +19,10 @@ public class RestaurantCreateRequest {
     private String description;
 
     @NotBlank(message = "전화번호는 비어있을 수 없습니다.")
-    @Pattern(regexp = "\\d{10,11}", message = "전화번호는 10자 이상 11자 이하의 숫자만 입력하세요.")
     private String phoneNumber;
 
-    @NotNull(message = "위도는 비어있을 수 없습니다.")
-    private BigDecimal latitude;
-
-    @NotNull(message = "경도는 비어있을 수 없습니다.")
-    private BigDecimal longitude;
+    @NotBlank(message = "주소는 비어있을 수 없습니다.")
+    private String address;
 
     @NotNull(message = "한식, 중식, 일식, 양식 중에 선택해주세요.")
     private FoodType foodType;

--- a/src/main/java/org/example/catch_line/restaurant/model/dto/RestaurantUpdateRequest.java
+++ b/src/main/java/org/example/catch_line/restaurant/model/dto/RestaurantUpdateRequest.java
@@ -1,0 +1,30 @@
+package org.example.catch_line.restaurant.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.example.catch_line.restaurant.model.entity.constant.FoodType;
+import org.example.catch_line.restaurant.model.entity.constant.ServiceType;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RestaurantUpdateRequest {
+
+    @NotBlank(message = "가게 이름은 비어있을 수 없습니다.")
+    private String name;
+
+    @NotBlank(message = "가게 소개 글은 비어있을 수 없습니다.")
+    private String description;
+
+    @NotBlank(message = "전화번호는 비어있을 수 없습니다.")
+    private String phoneNumber;
+
+    @NotNull(message = "한식, 중식, 일식, 양식 중에 선택해주세요.")
+    private FoodType foodType;
+
+    @NotNull(message = "줄서기, 예약 중에 선택해주세요.")
+    private ServiceType serviceType;
+}

--- a/src/main/java/org/example/catch_line/restaurant/model/entity/RestaurantEntity.java
+++ b/src/main/java/org/example/catch_line/restaurant/model/entity/RestaurantEntity.java
@@ -79,13 +79,13 @@ public class RestaurantEntity extends BaseTimeEntity {
 
 
     @Builder
-    public RestaurantEntity(String name, String description, Rating rating, PhoneNumber phoneNumber, BigDecimal latitude, BigDecimal longitude, FoodType foodType, ServiceType serviceType) {
+    public RestaurantEntity(String name, String description, Rating rating, PhoneNumber phoneNumber, FoodType foodType, ServiceType serviceType) {
         this.name = name;
         this.description = description;
         this.rating = rating;
         this.phoneNumber = phoneNumber;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.latitude = BigDecimal.ZERO;
+        this.longitude = BigDecimal.ZERO;
         this.scrapCount = 0L;
         this.reviewCount = 0L;
         this.foodType = foodType;
@@ -95,6 +95,15 @@ public class RestaurantEntity extends BaseTimeEntity {
     public void updateReview(Rating rating, Long reviewCount) {
         this.rating = rating;
         this.reviewCount = reviewCount;
+    }
+
+    // TODO: 위도, 경도 값도 수정할 수 있도록 변경
+    public void updateReservation(String name, String description, PhoneNumber phoneNumber, FoodType foodType, ServiceType serviceType) {
+        this.name = name;
+        this.description = description;
+        this.phoneNumber = phoneNumber;
+        this.foodType = foodType;
+        this.serviceType = serviceType;
     }
 
     // 사용자가 식당 스크랩 시 `scrapCount` 1 증가

--- a/src/main/java/org/example/catch_line/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/org/example/catch_line/restaurant/repository/RestaurantRepository.java
@@ -13,4 +13,5 @@ import java.util.Optional;
 public interface RestaurantRepository extends JpaRepository<RestaurantEntity, Long> {
 
     Optional<RestaurantEntity> findByName(String name);
+
 }

--- a/src/main/java/org/example/catch_line/restaurant/service/RestaurantScrapService.java
+++ b/src/main/java/org/example/catch_line/restaurant/service/RestaurantScrapService.java
@@ -7,9 +7,8 @@ import org.example.catch_line.member.repository.MemberRepository;
 import org.example.catch_line.member.validate.MemberValidator;
 import org.example.catch_line.restaurant.model.dto.RestaurantResponse;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
-import org.example.catch_line.restaurant.model.mapper.RestaurantHourMapper;
 import org.example.catch_line.restaurant.model.mapper.RestaurantMapper;
-import org.example.catch_line.restaurant.validate.RestaurantValidator;
+import org.example.catch_line.restaurant.validation.RestaurantValidator;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/org/example/catch_line/restaurant/service/RestaurantService.java
+++ b/src/main/java/org/example/catch_line/restaurant/service/RestaurantService.java
@@ -2,19 +2,22 @@ package org.example.catch_line.restaurant.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.catch_line.common.constant.Role;
 import org.example.catch_line.common.model.vo.Rating;
 import org.example.catch_line.member.model.vo.PhoneNumber;
 import org.example.catch_line.restaurant.model.dto.RestaurantCreateRequest;
 import org.example.catch_line.restaurant.model.dto.RestaurantResponse;
+import org.example.catch_line.restaurant.model.dto.RestaurantUpdateRequest;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
 import org.example.catch_line.restaurant.model.mapper.RestaurantMapper;
 import org.example.catch_line.restaurant.repository.RestaurantRepository;
-import org.example.catch_line.restaurant.validate.RestaurantValidator;
+import org.example.catch_line.restaurant.validation.RestaurantValidator;
 import org.example.catch_line.review.service.ReviewService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -50,6 +53,16 @@ public class RestaurantService {
         return RestaurantMapper.entityToResponse(entity);
     }
 
+//    public List<RestaurantResponse> findAllRestaurantByOwner(Long memberId, Role role) {
+//
+//    }
+
+    // TODO: 사장님 ID 넣어줘야 함.
+    public void updateRestaurant(Long restaurantId, RestaurantUpdateRequest request) {
+        RestaurantEntity entity = restaurantValidator.checkIfRestaurantPresent(restaurantId);
+        entity.updateReservation(request.getName(), request.getDescription(), new PhoneNumber(request.getPhoneNumber()), request.getFoodType(), request.getServiceType());
+    }
+
     public void deleteRestaurant(Long restaurantId) {
         restaurantRepository.deleteById(restaurantId);
     }
@@ -61,8 +74,6 @@ public class RestaurantService {
                 .name(request.getName())
                 .description(request.getDescription())
                 .phoneNumber(new PhoneNumber(request.getPhoneNumber()))
-                .latitude(request.getLatitude())
-                .longitude(request.getLongitude())
                 .foodType(request.getFoodType())
                 .serviceType(request.getServiceType())
                 .rating(new Rating(BigDecimal.valueOf(0)))

--- a/src/main/java/org/example/catch_line/restaurant/validation/RestaurantValidator.java
+++ b/src/main/java/org/example/catch_line/restaurant/validation/RestaurantValidator.java
@@ -1,4 +1,4 @@
-package org.example.catch_line.restaurant.validate;
+package org.example.catch_line.restaurant.validation;
 
 import lombok.RequiredArgsConstructor;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;

--- a/src/main/java/org/example/catch_line/review/service/ReviewService.java
+++ b/src/main/java/org/example/catch_line/review/service/ReviewService.java
@@ -5,7 +5,7 @@ import org.example.catch_line.common.model.vo.Rating;
 import org.example.catch_line.member.model.entity.MemberEntity;
 import org.example.catch_line.member.validate.MemberValidator;
 import org.example.catch_line.restaurant.model.entity.RestaurantEntity;
-import org.example.catch_line.restaurant.validate.RestaurantValidator;
+import org.example.catch_line.restaurant.validation.RestaurantValidator;
 import org.example.catch_line.review.model.dto.ReviewCreateRequest;
 import org.example.catch_line.review.model.dto.ReviewResponse;
 import org.example.catch_line.review.model.dto.ReviewUpdateRequest;

--- a/src/main/resources/templates/menu/menus.html
+++ b/src/main/resources/templates/menu/menus.html
@@ -12,6 +12,10 @@
         .card {
             margin-bottom: 20px;
         }
+        .btn-orange {
+            background-color: orange;
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -30,7 +34,7 @@
     </div>
     <div class="row">
         <div class="col">
-            <button class="w-100 btn btn-info btn-lg"
+            <button class="w-100 btn btn-orange btn-lg"
                     th:onclick="|location.href='@{/restaurants/{restaurantId}(restaurantId=${restaurantId})}'|"
                     type="button">뒤로</button>
         </div>

--- a/src/main/resources/templates/owner/createRestaurant.html
+++ b/src/main/resources/templates/owner/createRestaurant.html
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}" href="css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 800px;
+            margin-top: 20px;
+        }
+
+        .field-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+
+        .btn {
+            display: inline-block;
+            width: auto;
+        }
+
+        .btn-orange {
+            background-color: orange;
+            color: white;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="'식당 등록'">식당 추가</h2>
+    </div>
+
+    <form th:action th:object="${request}" method="post">
+
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="err : ${#fields.globalErrors()}" th:text="${err}">글로벌 오류 메시지</p>
+        </div>
+
+        <div>
+            <label for="name">식당 이름</label>
+            <input type="text" id="name" th:field="*{name}"
+                   th:errorclass="field-error" class="form-control" placeholder="식당 이름을 입력하세요">
+            <div class="field-error" th:errors="*{name}">
+                식당 이름 오류
+            </div>
+        </div>
+
+        <div>
+            <label for="nickname">식당 소개 글</label>
+            <input type="text" id="nickname" th:field="*{description}"
+                   th:errorclass="field-error" class="form-control" placeholder="식당 소개를 입력하세요">
+            <div class="field-error" th:errors="*{description}">
+                식당 소개 글 오류
+            </div>
+        </div>
+
+        <div>
+            <label for="phoneNumber">식당 전화번호</label>
+            <input type="text" id="phoneNumber" th:field="*{phoneNumber}"
+                   th:errorclass="field-error" class="form-control" placeholder="식당 전화번호를 입력하세요">
+            <div class="field-error" th:errors="*{phoneNumber}">
+                식당 전화번호 오류
+            </div>
+        </div>
+
+        <div>
+            <label for="address">식당 주소</label>
+            <input type="text" id="address" th:field="*{address}"
+                   th:errorclass="field-error" class="form-control" placeholder="식당 주소를 입력하세요">
+            <div class="field-error" th:errors="*{address}">
+                식당 주소 오류
+            </div>
+        </div>
+
+        <div>
+            <label>식당 음식 종류</label>
+            <div>
+                <label><input type="radio" th:field="*{foodType}" value="KOREAN"> 한식</label>
+                <label><input type="radio" th:field="*{foodType}" value="CHINESE"> 중식</label>
+                <label><input type="radio" th:field="*{foodType}" value="JAPANESE"> 일식</label>
+                <label><input type="radio" th:field="*{foodType}" value="WESTERN"> 양식</label>
+            </div>
+            <div class="field-error" th:errors="*{foodType}">
+                식당 음식 종류 오류
+            </div>
+        </div>
+
+        <div>
+            <label>식당 서비스 타입</label>
+            <div>
+                <label><input type="radio" th:field="*{serviceType}" value="WAITING"> 대기</label>
+                <label><input type="radio" th:field="*{serviceType}" value="RESERVATION"> 예약</label>
+            </div>
+            <div class="field-error" th:errors="*{serviceType}">
+                식당 서비스 타입 오류
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col">
+                <button class="w-100 btn btn-orange btn-lg"
+                        type="submit">식당 등록
+                </button>
+            </div>
+            <div class="col">
+                <button class="w-100 btn btn-orange btn-lg"
+                        th:onclick="|location.href='@{/owner}'|"
+                        type="button">취소</button>
+            </div>
+        </div>
+
+    </form>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/owner/owner.html
+++ b/src/main/resources/templates/owner/owner.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}" href="css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 800px;
+            margin-top: 20px;
+        }
+        .card {
+            margin-bottom: 20px;
+            padding: 20px;
+        }
+        .btn-container {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .btn {
+            display: inline-block;
+            width: auto;
+        }
+        .btn-orange {
+            background-color: orange;
+            color: white;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2 class="card-title text-center">식당 관리자 페이지</h2>
+    <hr class="my-4">
+    <div class="card">
+        <div class="card-body btn-container">
+            <button type="button" class="btn btn-orange"
+                    th:onclick="|location.href='@{/owner/restaurants}'|">식당 추가</button>
+        </div>
+        <div class="card-body btn-container">
+            <button type="button" class="btn btn-orange"
+                    th:onclick="|location.href='@{/owner/restaurants}'|">식당 관리</button>
+        </div>
+        <div class="card-body btn-container">
+            <button type="button" class="btn btn-orange">예약 관리</button>
+        </div>
+        <div class="card-body btn-container">
+            <button type="button" class="btn btn-orange">웨이팅 관리</button>
+        </div>
+    </div>
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/owner/restaurantList.html
+++ b/src/main/resources/templates/owner/restaurantList.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/owner/updateRestaurant.html
+++ b/src/main/resources/templates/owner/updateRestaurant.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/restaurant/restaurant.html
+++ b/src/main/resources/templates/restaurant/restaurant.html
@@ -15,18 +15,23 @@
         .phone-number {
             margin-top: 20px;
         }
+        .btn-orange {
+            background-color: orange;
+            color: white;
+        }
     </style>
 </head>
 <div class="container">
 
+    <div class="col text-center">
+        <h2 th:text="#{restaurant.information}">식당 정보</h2>
+    </div>
+
     <div class="row mb-4 btn-container">
         <div class="col-auto">
-            <button class="btn btn-secondary btn-lg"
+            <button class="btn btn-orange btn-lg"
                     th:onclick="|location.href='@{/restaurants}'|"
-                    type="button">홈</button>
-        </div>
-        <div class="col text-center">
-            <h2 th:text="#{restaurant.information}">식당 정보</h2>
+                    type="button">뒤로</button>
         </div>
     </div>
 
@@ -60,12 +65,12 @@
                     type="button">홈</button>
         </div>
         <div class="col">
-            <button class="w-100 btn btn-info btn-lg"
+            <button class="w-100 btn btn-orange btn-lg"
                     th:onclick="|location.href='@{/restaurants/{restaurantId}/menus(restaurantId=${restaurant.restaurantId})}'|"
                     type="button">메뉴</button>
         </div>
         <div class="col">
-            <button class="w-100 btn btn-info btn-lg"
+            <button class="w-100 btn btn-orange btn-lg"
                     th:onclick="|location.href='@{/restaurants/{restaurantId}/reviews(restaurantId=${restaurant.restaurantId})}'|"
                     type="button">리뷰</button>
         </div>

--- a/src/main/resources/templates/restaurant/restaurantPreview.html
+++ b/src/main/resources/templates/restaurant/restaurantPreview.html
@@ -31,6 +31,32 @@
         .sort-buttons .btn {
             margin: 0 5px;
         }
+        .btn-orange {
+            background-color: orange;
+            color: white;
+        }
+        .btn-orange.active {
+            background-color: white;
+            color: black;
+            border: 1px solid black;
+        }
+        .page-link {
+            color: white;
+            background-color: orange;
+            border-color: orange;
+        }
+        .page-link:hover {
+            background-color: darkorange;
+            border-color: darkorange;
+        }
+        .page-item.active .page-link {
+            background-color: white;
+            color: black;
+            border-color: black;
+        }
+        .list-group-item {
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>
@@ -54,11 +80,11 @@
     <!-- 정렬 버튼들 -->
     <div class="sort-buttons">
         <a th:href="@{/restaurants(criteria='reviewCount', page=0, size=${restaurantPreviewPage.size})}"
-           class="btn btn-primary" th:classappend="${criteria == 'reviewCount'} ? 'active' : ''">리뷰 순</a>
+           class="btn btn-orange" th:classappend="${criteria == 'reviewCount'} ? 'active' : ''">리뷰 순</a>
         <a th:href="@{/restaurants(criteria='scrapCount', page=0, size=${restaurantPreviewPage.size})}"
-           class="btn btn-primary" th:classappend="${criteria == 'scrapCount'} ? 'active' : ''">스크랩 순</a>
+           class="btn btn-orange" th:classappend="${criteria == 'scrapCount'} ? 'active' : ''">스크랩 순</a>
         <a th:href="@{/restaurants(criteria='rating', page=0, size=${restaurantPreviewPage.size})}"
-           class="btn btn-primary" th:classappend="${criteria == 'rating'} ? 'active' : ''">별점 순</a>
+           class="btn btn-orange" th:classappend="${criteria == 'rating'} ? 'active' : ''">별점 순</a>
     </div>
 
     <div class="card">

--- a/src/main/resources/templates/review/reviews.html
+++ b/src/main/resources/templates/review/reviews.html
@@ -12,6 +12,10 @@
         .card {
             margin-bottom: 20px;
         }
+        .btn-orange {
+            background-color: orange;
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -31,7 +35,7 @@
     </div>
     <div class="row">
         <div class="col">
-            <button class="w-100 btn btn-info btn-lg"
+            <button class="w-100 btn btn-orange btn-lg"
                     th:onclick="|location.href='@{/restaurants/{restaurantId}(restaurantId=${restaurantId})}'|"
                     type="button">뒤로</button>
         </div>


### PR DESCRIPTION
1. 사장님 기능 구현 
식당 추가만 완료하고 잠시 중단
2. 화면 컬러 주황색으로 통일

### 주요 사항
현재 사장님이 가져야 할 기능은 총 4가지 입니다.
식당 추가, 식당 관리(수정, 삭제), 예약 관리(예약 상태 변경), 웨이팅 관리(웨이팅 상태 관리)

현재 Member table에서 Role을 통해 손님, 사장님으로 구분하고 있습니다
주로 손님과 관련된 로직만 작성하여 손님이 식당 테이블에 직접 접근하는 것을 고려하고 있지 않았습니다.
반면에 사장님의 경우 식당 추가, 수정, 삭제 등 관리가 필요합니다.
이 때 사장님이라는 것을 판단할 때, memberId, Role == OWNER 두 경우를 판단을 해야 합니다.

위 조건을 검사하려고 하니 식당 테이블에서 멤버 테이블로 연관 관계를 지어놓지 않아 접근이 불가능하게 되었습니다.

이를 해결하고자 떠올린 방법이 2가지가 있습니다.
1. Member 테이블과 Restaurant 테이블의 연관 관계를 짓는다.
2. Owner 테이블을 따로 생성해서 식당, 예약, 웨이팅 연관 관계를 짓는다.

저는 1번 방식은 좋지 않다고 생각합니다.
그 이유는 Owner인 경우를 제대로 확인하지 못했을 때 일반 사용자가 식당 수정, 삭제가 가능하게 된다는 점입니다.
그렇기 때문에 테이블을 따로 둔다면 이런 경우가 발생할 가능성이 없다고 생각하여 2번 방식이 좋다고 생각합니다.
2번 방식은 테이블 연관관계를 추가적으로 더 지어야 하기 때문에 테이블 간 관계가 복잡해질 수 있다고 생각합니다.

그렇기에 1번, 2번 방식 중에 더 좋은 방식을 고민해보면 좋을 것 같습니다. 