### PR TITLE
[Feature] 예약 동시성 테스트

### DIFF
--- a/src/main/java/org/example/catch_line/booking/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/example/catch_line/booking/reservation/repository/ReservationRepository.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.persistence.LockModeType;
 import org.example.catch_line.booking.reservation.model.entity.ReservationEntity;
 import org.example.catch_line.common.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,7 +24,10 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
 
 	List<ReservationEntity> findAllByStatus(Status status);
 
-	List<ReservationEntity> findByRestaurantRestaurantIdAndReservationDate(Long restaurantId, LocalDateTime reservationDate);
+//	List<ReservationEntity> findByRestaurantRestaurantIdAndReservationDate(Long restaurantId, LocalDateTime reservationDate);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<ReservationEntity> findByRestaurantRestaurantIdAndReservationDate(Long restaurantId, LocalDateTime reservationDate);
 }
 
 

--- a/src/main/java/org/example/catch_line/booking/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/catch_line/booking/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package org.example.catch_line.booking.reservation.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.example.catch_line.booking.reservation.model.dto.ReservationRequest;
 import org.example.catch_line.booking.reservation.model.dto.ReservationResponse;
 import org.example.catch_line.booking.reservation.model.entity.ReservationEntity;
@@ -24,7 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 //@Transactional
@@ -38,9 +41,9 @@ public class ReservationService {
 	private final RestaurantValidator restaurantValidator;
 	private final HistoryMapper historyMapper;
 
-	@Transactional(isolation = Isolation.READ_COMMITTED)
+	@Transactional
 	public ReservationResponse addReservation(Long memberId, Long restaurantId, ReservationRequest reservationRequest) {
-		if (isReservationTimeConflict(restaurantId, reservationRequest.getReservationDate())) {
+		if(isReservationTimeConflict(restaurantId, reservationRequest.getReservationDate())) {
 			throw new DuplicateReservationTimeException();
 		}
 
@@ -67,7 +70,7 @@ public class ReservationService {
 				.getRestaurantId();
 		MemberEntity member = memberValidator.checkIfMemberPresent(memberId);
 
-		if (isReservationTimeConflict(restaurantId, reservationDate)) {
+		if(isReservationTimeConflict(restaurantId, reservationDate)) {
 			throw new DuplicateReservationTimeException();
 		}
 
@@ -112,8 +115,8 @@ public class ReservationService {
 	}
 
 	private boolean isReservationTimeConflict(Long restaurantId, LocalDateTime reservationDate) {
-		List<ReservationEntity> existingReservations = reservationRepository.findByRestaurantRestaurantIdAndReservationDate(restaurantId, reservationDate);
-		return !existingReservations.isEmpty();
+		Optional<ReservationEntity> reservationEntityOptional = reservationRepository.findByRestaurantRestaurantIdAndReservationDate(restaurantId, reservationDate);
+		return reservationEntityOptional.isPresent();
 	}
 
 }

--- a/src/test/java/org/example/catch_line/concurrency/ConcurrencyTest2.java
+++ b/src/test/java/org/example/catch_line/concurrency/ConcurrencyTest2.java
@@ -42,38 +42,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스당 하나의 인스턴스만 생성
 public class ConcurrencyTest2 {
 
-    @Autowired
-    private ReservationService reservationService;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private RestaurantRepository restaurantRepository;
-
-    private RestaurantEntity restaurantEntity1;
-
+    @Autowired private ReservationService reservationService;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private RestaurantRepository restaurantRepository;
+    @Autowired private WaitingService waitingService;
+    @Autowired private WaitingRepository waitingRepository;
     @Autowired private PasswordEncoder passwordEncoder;
+    RestaurantEntity restaurantEntity1;
+    RestaurantEntity restaurantEntity2;
+    ReservationRequest reservationRequest1;
+    ReservationRequest reservationRequest2;
+    WaitingRequest waitingRequest1;
 
     @BeforeAll
     void setup() {
-        memberSave();
+         reservationRequest1 = ReservationRequest.builder()
+                .memberCount(3)
+                .reservationDate(LocalDateTime.of(2024, 8, 22, 15, 0)) // 2024년 8월 22일 오후 3시 00분
+                .build();
+         reservationRequest2 = ReservationRequest.builder()
+                .memberCount(3)
+                .reservationDate(LocalDateTime.of(2024, 9, 22, 15, 0)) // 2024년 8월 22일 오후 3시 00분
+                .build();
+         waitingRequest1 = WaitingRequest.builder()
+                .memberCount(3)
+                .waitingType(WaitingType.TAKE_OUT)
+                .build();
+         memberSave();
     }
-
-    ReservationRequest reservationRequest1 = ReservationRequest.builder()
-            .memberCount(3)
-            .reservationDate(LocalDateTime.of(2024, 8, 22, 15, 0)) // 2024년 8월 22일 오후 3시 00분
-            .build();
-
-    ReservationRequest reservationRequest2 = ReservationRequest.builder()
-            .memberCount(3)
-            .reservationDate(LocalDateTime.of(2024, 9, 22, 15, 0)) // 2024년 8월 22일 오후 3시 00분
-            .build();
-
 
     @Test
     @DisplayName("식당 동시 예약 200명 - List에 1~200 넣고 Shuffle")
     void testRestaurantConcurrency100() throws InterruptedException {
+        // given
         int numberOfThreads = 200;
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
@@ -84,6 +85,7 @@ public class ConcurrencyTest2 {
         List<Integer> memberIds = IntStream.rangeClosed(1, 201).boxed().collect(Collectors.toList());
         Collections.shuffle(memberIds);
 
+        // when
         for (int i = 1; i <= numberOfThreads; i++) {
             int randomMemberId = memberIds.get(i);
             executorService.submit(() -> {
@@ -99,17 +101,18 @@ public class ConcurrencyTest2 {
 
         }
         latch.await(); // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
 
+        // then
         // 한 명의 사용자만 성공해야 함을 검증
         assertThat(successfulReservations.get()).isEqualTo(1);
         assertThat(failedReservations.get()).isEqualTo(199);
-
-        executorService.shutdown();
     }
 
     @Test
     @DisplayName("식당 동시 예약 - ThreadLocalRandom")
     void testRestaurantConcurrency_not_run() throws InterruptedException {
+        // given
         int numberOfThreads = 200;
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
@@ -117,6 +120,7 @@ public class ConcurrencyTest2 {
         AtomicInteger successfulReservations = new AtomicInteger(); // 성공한 예약의 수를 카운트
         AtomicInteger failedReservations = new AtomicInteger(); // 실패한 예약의 수를 카운트
 
+        // when
         for (int i = 1; i <= numberOfThreads; i++) {
             executorService.submit(() -> {
                 long randomMemberId = ThreadLocalRandom.current().nextLong(1, 201); // 1부터 200 사이의 랜덤 ID 선택
@@ -131,16 +135,50 @@ public class ConcurrencyTest2 {
             });
         }
         latch.await(); // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
 
+        // then
         // 한 명의 사용자만 성공해야 함을 검증
         assertThat(successfulReservations.get()).isEqualTo(1);
         assertThat(failedReservations.get()).isEqualTo(199);
+    }
 
+    @Test
+    @DisplayName("식당 웨이팅 등록을 20명이 동시에 했을 때 -> 웨이팅 등록 번호가 1~20까지 잘 등록되는지 확인")
+    public void testWaitingRegistration() throws InterruptedException {
+        // given
+        List<WaitingEntity> beforeWaitings = waitingRepository.findAll();
+        int size = beforeWaitings.size();
+        int numberOfThreads = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        //when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                long randomMemberId = ThreadLocalRandom.current().nextLong(1, 201);
+                try {
+                    waitingService.addWaiting(restaurantEntity2.getRestaurantId(), waitingRequest1, randomMemberId);
+                } catch (Exception e) {
+                    e.printStackTrace(); // 예외 발생 시 스택 트레이스를 출력
+                } finally {
+                    latch.countDown(); // 작업이 완료되면 CountDownLatch의 카운트를 감소시킴
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 완료될 때까지 대기
         executorService.shutdown();
+        List<WaitingEntity> afterWaitings = waitingRepository.findAll();
+
+        // then
+        assertThat(afterWaitings).hasSize(size + numberOfThreads);
     }
 
     private void memberSave() {
         this.restaurantEntity1 = restaurantRepository.findById(1L).orElseThrow();
+        this.restaurantEntity2 = restaurantRepository.findById(2L).orElseThrow();
+
         for (int i = 0; i < 200; i++) {
             MemberEntity member = MemberEntity.builder()
                     .email(new Email("abc" + i + "@gmail.com"))

--- a/src/test/java/org/example/catch_line/concurrency/ConcurrencyTest2.java
+++ b/src/test/java/org/example/catch_line/concurrency/ConcurrencyTest2.java
@@ -1,0 +1,157 @@
+package org.example.catch_line.concurrency;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.catch_line.CatchLineApplication;
+import org.example.catch_line.booking.reservation.model.dto.ReservationRequest;
+import org.example.catch_line.booking.reservation.service.ReservationService;
+import org.example.catch_line.booking.waiting.model.dto.WaitingRequest;
+import org.example.catch_line.booking.waiting.model.entity.WaitingEntity;
+import org.example.catch_line.booking.waiting.model.entity.WaitingType;
+import org.example.catch_line.booking.waiting.repository.WaitingRepository;
+import org.example.catch_line.booking.waiting.service.WaitingService;
+import org.example.catch_line.common.model.vo.Email;
+import org.example.catch_line.common.model.vo.Password;
+import org.example.catch_line.common.model.vo.PhoneNumber;
+import org.example.catch_line.dining.restaurant.model.entity.RestaurantEntity;
+import org.example.catch_line.dining.restaurant.repository.RestaurantRepository;
+import org.example.catch_line.exception.booking.DuplicateReservationTimeException;
+import org.example.catch_line.user.member.model.entity.MemberEntity;
+import org.example.catch_line.user.member.repository.MemberRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest(classes = CatchLineApplication.class)
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스당 하나의 인스턴스만 생성
+public class ConcurrencyTest2 {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    private RestaurantEntity restaurantEntity1;
+
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    @BeforeAll
+    void setup() {
+        memberSave();
+    }
+
+    ReservationRequest reservationRequest1 = ReservationRequest.builder()
+            .memberCount(3)
+            .reservationDate(LocalDateTime.of(2024, 8, 22, 15, 0)) // 2024년 8월 22일 오후 3시 00분
+            .build();
+
+    ReservationRequest reservationRequest2 = ReservationRequest.builder()
+            .memberCount(3)
+            .reservationDate(LocalDateTime.of(2024, 9, 22, 15, 0)) // 2024년 8월 22일 오후 3시 00분
+            .build();
+
+
+    @Test
+    @DisplayName("식당 동시 예약 200명 - List에 1~200 넣고 Shuffle")
+    void testRestaurantConcurrency100() throws InterruptedException {
+        int numberOfThreads = 200;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successfulReservations = new AtomicInteger(); // 성공한 예약의 수를 카운트
+        AtomicInteger failedReservations = new AtomicInteger(); // 실패한 예약의 수를 카운트
+
+        List<Integer> memberIds = IntStream.rangeClosed(1, 201).boxed().collect(Collectors.toList());
+        Collections.shuffle(memberIds);
+
+        for (int i = 1; i <= numberOfThreads; i++) {
+            int randomMemberId = memberIds.get(i);
+            executorService.submit(() -> {
+                try {
+                    reservationService.addReservation((long) randomMemberId, restaurantEntity1.getRestaurantId(), reservationRequest1);
+                    successfulReservations.incrementAndGet();
+                } catch (DuplicateReservationTimeException e) {
+                    failedReservations.incrementAndGet(); // 예약이 실패했을 경우
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+        }
+        latch.await(); // 모든 스레드가 완료될 때까지 대기
+
+        // 한 명의 사용자만 성공해야 함을 검증
+        assertThat(successfulReservations.get()).isEqualTo(1);
+        assertThat(failedReservations.get()).isEqualTo(199);
+
+        executorService.shutdown();
+    }
+
+    @Test
+    @DisplayName("식당 동시 예약 - ThreadLocalRandom")
+    void testRestaurantConcurrency_not_run() throws InterruptedException {
+        int numberOfThreads = 200;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successfulReservations = new AtomicInteger(); // 성공한 예약의 수를 카운트
+        AtomicInteger failedReservations = new AtomicInteger(); // 실패한 예약의 수를 카운트
+
+        for (int i = 1; i <= numberOfThreads; i++) {
+            executorService.submit(() -> {
+                long randomMemberId = ThreadLocalRandom.current().nextLong(1, 201); // 1부터 200 사이의 랜덤 ID 선택
+                try {
+                    reservationService.addReservation(randomMemberId, restaurantEntity1.getRestaurantId(), reservationRequest2);
+                    successfulReservations.incrementAndGet();
+                } catch (DuplicateReservationTimeException e) {
+                    failedReservations.incrementAndGet(); // 예약이 실패했을 경우
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await(); // 모든 스레드가 완료될 때까지 대기
+
+        // 한 명의 사용자만 성공해야 함을 검증
+        assertThat(successfulReservations.get()).isEqualTo(1);
+        assertThat(failedReservations.get()).isEqualTo(199);
+
+        executorService.shutdown();
+    }
+
+    private void memberSave() {
+        this.restaurantEntity1 = restaurantRepository.findById(1L).orElseThrow();
+        for (int i = 0; i < 200; i++) {
+            MemberEntity member = MemberEntity.builder()
+                    .email(new Email("abc" + i + "@gmail.com"))
+                    .name("홍길동")
+                    .nickname("hong")
+                    .password(new Password(passwordEncoder.encode("123qwe!@Q")))
+                    .phoneNumber(new PhoneNumber("010-1234-1234"))
+                    .build();
+
+            memberRepository.save(member);
+        }
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,13 +1,11 @@
-spring.datasource.url=jdbc:h2:tcp://localhost/~/test
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.h2.console.enabled=true
+spring.datasource.url=jdbc:mysql://localhost:3306/catch_line_db
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 # message
 spring.messages.encoding=UTF-8


### PR DESCRIPTION
### 구현 사항
200명이 동시에 동일한 시간에 식당에 예약을 했을 때 한 명의 사용자만 예약이 가능해야 합니다.
1. `synchronized`를 사용하여 한 명의 사용자만 식당에 예약되는 것을 확인했습니다.
```java
@Transactional
public synchronized ReservationResponse addReservation(Long memberId, Long restaurantId, ReservationRequest reservationRequest) {
```
2. `비관적 락`을 통해 한 명의 사용자만 식당에 예약되는 것을 확인했습니다.
```java
@Lock(LockModeType.PESSIMISTIC_WRITE)
Optional<ReservationEntity> findByRestaurantRestaurantIdAndReservationDate(Long restaurantId, LocalDateTime reservationDate);
```
```java
@Transactional
public ReservationResponse addReservation(Long memberId, Long restaurantId, ReservationRequest reservationRequest) {
```
- - -
### 문제 상황 (memberId)
처음 `synchronized`를 시도하여 성공하였을 때 `memberId`가 `Reservation Table`에 0~50 사이로만 기록되는 문제가 있었습니다.
단순히 `synchronized` 문제라 판단하여 `낙관적 락`, `비관적 락`을 사용하면 해결 될 것으로 생각하였습니다.

`낙관적 락`은 insert가 아닌 `update`할 때만 `version`이 증가하기 때문에 저희 서비스에는 적용되지 않을 것이라 판단하였습니다.
그렇기 때문에 비관적 락을 사용하면 문제가 해결될 것이라 생각하였습니다.

`비관적 락`을 사용한 결과, `synchronized`와 같이 `memberId`가 51~200까지 기록되지 않았습니다.
그렇다면 `ReservationService` 쪽 문제라고 판단하여 검증하는 부분을 변경해보았습니다.
```java
private boolean isReservationTimeConflict(Long restaurantId, LocalDateTime reservationDate) {
	List<ReservationEntity> existingReservations = reservationRepository.findByRestaurantRestaurantIdAndReservationDate(restaurantId, reservationDate);
	return !existingReservations.isEmpty();
}
```
```java
private boolean isReservationTimeConflict(Long restaurantId, LocalDateTime reservationDate) {
	Optional<ReservationEntity> reservationEntityOptional = reservationRepository.findByRestaurantRestaurantIdAndReservationDate(restaurantId, reservationDate);
	return reservationEntityOptional.isPresent();

@Transactional
public ReservationResponse addReservation(Long memberId, Long restaurantId, ReservationRequest reservationRequest) {
	if(isReservationTimeConflict(restaurantId, reservationRequest.getReservationDate())) {
		throw new DuplicateReservationTimeException();
	}
}
```
이 방법도 `memberId` 문제를 해결하지 못하였습니다.
서비스 로직에는 문제가 없다고 판단하였고, 어떤 것을 고쳐야 할까 고민을 하는 시간을 갖게 되었습니다.
그 결과 테스트 코드 쪽에 `memberId`를 넣어주는 부분이 잘못되었다는 것을 깨닫게 되었습니다.

#### 기존 코드
```java
    @Test
    @DisplayName("식당 동시 예약 100명")
    void testRestaurantConcurrency() throws InterruptedException {
        int numberOfThreads = 200; 
        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
        CountDownLatch latch = new CountDownLatch(numberOfThreads);

        AtomicInteger successfulReservations = new AtomicInteger(); // 성공한 예약의 수를 카운트
        AtomicInteger failedReservations = new AtomicInteger(); // 실패한 예약의 수를 카운트

        for (int i = 1; i <= numberOfThreads; i++) {
            // 수정될 부분
            int finalI = i;
            MemberEntity member = memberRepository.findById(Long.valueOf(finalI)).orElseThrow(() -> new IllegalArgumentException("id : " + finalI));
            executorService.submit(() -> {
                try {
                    reservationService.addReservation(member.getMemberId(), restaurantEntity1.getRestaurantId(), reservationRequest2);
                    successfulReservations.incrementAndGet();
                } catch (DuplicateReservationTimeException e) {
                    failedReservations.incrementAndGet(); // 예약이 실패했을 경우
                } finally {
                    latch.countDown();
                }
            });
        }

        latch.await(); // 모든 스레드가 완료될 때까지 대기

        // 한 명의 사용자만 성공해야 함을 검증
        assertThat(successfulReservations.get()).isEqualTo(1);
        assertThat(failedReservations.get()).isEqualTo(199);

        executorService.shutdown();
    }
```

#### 수정된 코드
```java
    @Test
    @DisplayName("식당 동시 예약 - ThreadLocalRandom")
    void testRestaurantConcurrency() throws InterruptedException {
        int numberOfThreads = 200;
        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
        CountDownLatch latch = new CountDownLatch(numberOfThreads);

        AtomicInteger successfulReservations = new AtomicInteger(); // 성공한 예약의 수를 카운트
        AtomicInteger failedReservations = new AtomicInteger(); // 실패한 예약의 수를 카운트

        for (int i = 1; i <= numberOfThreads; i++) {
            // 수정된 부분
            executorService.submit(() -> {
                long randomMemberId = ThreadLocalRandom.current().nextLong(1, 201); // 1부터 200 사이의 랜덤 ID 선택
                try {
                    reservationService.addReservation(randomMemberId, restaurantEntity1.getRestaurantId(), reservationRequest2);
                    successfulReservations.incrementAndGet();
                } catch (DuplicateReservationTimeException e) {
                    failedReservations.incrementAndGet(); // 예약이 실패했을 경우
                } finally {
                    latch.countDown();
                }
            });
        }
        latch.await(); // 모든 스레드가 완료될 때까지 대기

        // 한 명의 사용자만 성공해야 함을 검증
        assertThat(successfulReservations.get()).isEqualTo(1);
        assertThat(failedReservations.get()).isEqualTo(199);

        executorService.shutdown();
    }
```
기존에는 for문을 돌면서 1부터 200까지 `memberId` 값을 순서로 넣어주고 있었습니다.
위 방식대로 하게 되면 항상 for문 초반에 `memberId` 값이 들어가게 되어 0~50 사이의 값이 기록이 되었던 것이라 판단했습니다.

멀티스레드 환경에서 동시에 예약을 한다면 1~200까지 순서대로 들어오는 것이 아니라 어떤 값이 들어올 지 모른다는 생각이 들었습니다.
그렇기 때문에 `memberId` 값을 `랜덤`으로 부여해주면 계속 발생했던 문제가 해결되지 않을까 생각하게 되었습니다.

`ThreadLocalRandom.current().nextLong(1, 201)`를 이용하여 해당 문제를 해결하게 되었습니다.

문제는 해결하였지만, 이러한 테스트 방식이 올바른 방식인지는 모르겠습니다.
`더 좋은 방식` 혹은 `올바른 방식`이 있는지 알려주시면 감사하겠습니다!

### 결론
그렇다면, 저희는 `sychronized`, `비관적 락`으로 동시성 문제를 해결할 수 있다고 생각합니다.
더 많은 동시성 테스트를 진행해봐야 하고, 식당에 1명만 예약 가능이 아닌 10명, 20명 예약도 가능하도록 변경해봐야 합니다.

저는 개인적으로 `비관적 락`을 사용하는 방식이 좋다고 생각합니다.
그 이유는 `thread가 조회`할 때부터 `lock`을 걸기 때문에 확실하게 동시성 문제를 해결할 수 있다고 생각합니다.

`sychronized`의 경우 여러 개의 스레드가 한 개의 자원을 사용하고자 할 때, 현재 자원을 사용하고 있는 해당 스레드를 제외하고 나머지 스레드들은 자원에 접근 할 수 없도록 막는 개념입니다.
개념만 보았을 때 확실히 동시성 문제를 막을 수 있을 것 같지만, `메서드 자체에 락`을 걸어야 하기 때문에 다른 스레드 혹은 유저는 `대기`해야 합니다. 이 방식은 `성능 상 비효율적`이라는 판단이 들었고, `@Transactional`과 같이 사용 시 `데이터 정합성을 보장할 수 없다`는 문제도 있습니다.
그렇기 때문에 저는 `비관적 락`을 사용하는 것이 더 좋다는 생각을 가지고 있습니다.
- - -

### 또 다른 문제
`H2`를 이용하여 동시성 테스트를 시도하였으나, `비관적 락이 지원되지 않아` 계속해서 테스트가 실패하였습니다.
이를 해결하기 위해 실제 사용하는 `MySQL DB`를 이용하였습니다.
배포된 데이터는 건들지 않는 방식으로 local에 있는 MySQL만 이용하도록 할 계획입니다.
