### PR TITLE
[Refactoring] SSE Exception 문제 해결

### DIFF
--- a/src/main/java/org/example/catch_line/booking/waiting/service/WaitingService.java
+++ b/src/main/java/org/example/catch_line/booking/waiting/service/WaitingService.java
@@ -36,6 +36,7 @@ public class WaitingService {
 	private final MemberValidator memberValidator;
 	private final RestaurantValidator restaurantValidator;
 
+	@Transactional(readOnly = true)
 	public WaitingEntity getWaitingEntity(Long waitingId) {
 		return waitingRepository.findById(waitingId)
 				.orElseThrow(() -> new WaitingException("웨이팅이 존재하지 않습니다."));

--- a/src/main/java/org/example/catch_line/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/catch_line/exception/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.io.IOException;
+
 @Slf4j
 // TODO: RestControllerAdvice vs ControllerAdvice 어노테이션
 @RestControllerAdvice
@@ -24,6 +26,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleCatchLineException(CatchLineException e) {
         log.error("캐치라인 커스텀 예외 발생: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<String> handleIOException(IOException e) {
+        log.error("IOException 예외 발생: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/example/catch_line/history/service/HistoryService.java
+++ b/src/main/java/org/example/catch_line/history/service/HistoryService.java
@@ -16,9 +16,11 @@ import org.example.catch_line.history.model.mapper.HistoryMapper;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class HistoryService {
 
 	private final WaitingRepository waitingRepository;

--- a/src/main/java/org/example/catch_line/notification/controller/NotificationController.java
+++ b/src/main/java/org/example/catch_line/notification/controller/NotificationController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class NotificationController {
 
-    @GetMapping(value = "/notification")
+    @GetMapping(value = "/notifications")
     public String notification() {
         return "notification/notification";
     }

--- a/src/main/java/org/example/catch_line/notification/controller/NotificationRestController.java
+++ b/src/main/java/org/example/catch_line/notification/controller/NotificationRestController.java
@@ -3,6 +3,9 @@ package org.example.catch_line.notification.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.catch_line.notification.service.NotificationService;
+import org.example.catch_line.user.auth.details.MemberUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -16,10 +19,12 @@ public class NotificationRestController {
 
     private final NotificationService notificationService;
 
-    @GetMapping(value = "/sse/{id}", produces = "text/event-stream")
-    public SseEmitter subscribe(@PathVariable Long id,
+    @GetMapping(value = "/notifications/sse", produces = "text/event-stream")
+    public SseEmitter subscribe(@AuthenticationPrincipal MemberUserDetails userDetails,
                                 @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+
         log.info("SSE 연결");
-        return notificationService.connect(id, lastEventId);
+        Long memberId = userDetails.getMember().getMemberId();
+        return notificationService.connect(memberId, lastEventId);
     }
 }

--- a/src/main/java/org/example/catch_line/notification/service/NotificationService.java
+++ b/src/main/java/org/example/catch_line/notification/service/NotificationService.java
@@ -34,12 +34,10 @@ public class NotificationService {
         SseEmitter emitter = emitterRepository.save(id, new SseEmitter(DEFAULT_TIMEOUT));
 
         emitter.onCompletion(() -> {
-            log.info("연결이 완료되었습니다. ID: {}", id);
             emitterRepository.deleteById(id);
         });
 
         emitter.onTimeout(() -> {
-            log.info("연결이 타임아웃되었습니다. ID: {}", id);
             emitterRepository.deleteById(id);
         });
 

--- a/src/main/java/org/example/catch_line/review/service/ReviewService.java
+++ b/src/main/java/org/example/catch_line/review/service/ReviewService.java
@@ -32,6 +32,7 @@ public class ReviewService {
 	private final ReviewValidator reviewValidator;
 	private final ReviewMapper reviewMapper;
 
+	@Transactional(readOnly = true)
 	public List<ReviewResponse> getRestaurantReviewList(Long restaurantId) {
 		List<ReviewEntity> reviewList = reviewRepository.findAllByRestaurantRestaurantIdOrderByCreatedAtDesc(restaurantId);
 
@@ -40,6 +41,7 @@ public class ReviewService {
 			.collect(Collectors.toList());
 	}
 
+	@Transactional(readOnly = true)
 	public ReviewResponse getReviewById(Long reviewId, Long memberId) {
 		ReviewEntity reviewEntity = reviewValidator.checkIfReviewPresent(reviewId);
 		isMemberOfReview(reviewEntity, memberId);

--- a/src/main/java/org/example/catch_line/user/member/service/MyReviewService.java
+++ b/src/main/java/org/example/catch_line/user/member/service/MyReviewService.java
@@ -7,6 +7,7 @@ import org.example.catch_line.review.model.mapper.ReviewMapper;
 import org.example.catch_line.review.repository.ReviewRepository;
 import org.example.catch_line.user.member.model.dto.MyReviewResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +19,7 @@ public class MyReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewMapper reviewMapper;
 
+    @Transactional(readOnly = true)
     public List<MyReviewResponse> getMyReviewList(Long memberId) {
         List<ReviewEntity> reviewList = reviewRepository.findAllByMemberMemberIdOrderByCreatedAtDesc(memberId);
 

--- a/src/main/resources/templates/notification/notification.html
+++ b/src/main/resources/templates/notification/notification.html
@@ -93,10 +93,6 @@
 <div class="container">
     <h1>SSE 연결</h1>
     <div class="form-group">
-        <label for="id">ID:</label>
-        <input type="text" id="id" class="form-control" placeholder="ID를 입력하세요" required/>
-    </div>
-    <div class="form-group">
         <button type="button" class="btn btn-orange" onclick="login()">연결</button>
     </div>
     <div class="form-group">
@@ -109,13 +105,11 @@
     let eventSource = null;
 
     function login() {
-        const id = document.getElementById('id').value;
-
         if (eventSource) {
             eventSource.close(); // 기존 연결이 있다면 끊기
         }
 
-        eventSource = new EventSource(`/sse/` + id);
+        eventSource = new EventSource(`/notifications/sse`);
 
         eventSource.onopen = function () {
             document.getElementById('status').innerText = "연결되었습니다.";

--- a/src/main/resources/templates/restaurant/restaurantPreview.html
+++ b/src/main/resources/templates/restaurant/restaurantPreview.html
@@ -166,7 +166,7 @@
             </form>
             <button class="btn btn-outline-secondary" th:onclick="|location.href='@{/history}'|" type="button">나의 예약</button>
             <button class="btn btn-outline-secondary" th:onclick="|location.href='@{/members}'|" type="button">내 프로필</button>
-            <a href="/notification" target="_blank">
+            <a href="/notifications" target="_blank">
                 <button class="btn btn-outline-secondary" id="notificationButton" type="button">알림 연결 창</button>
             </a>
         </div>


### PR DESCRIPTION
### 개요
연결을 끊고 예약 혹은 웨이팅을 했을 때 IOException이 3번 발생하게 되는 문제가 있었음.
E2E 프로젝트 완성을 위해 알림 기능은 동작하기 때문에 미루게 되었음.
현재 다시 리팩토링을 진행하여 해당 문제를 해결하고자 하였음.

### 해결 방안
OSIV 설정도 꺼보고, 디버깅도 해보고, ExceptionHandler로 이용해보고 하여 문제를 해결하고자 하였다.
이런 방안들을 가지고 해결하고자 하였는데 실패하였으나, 결론은 ExceptionHandler를 통해 해결이 되었다.

처음 1번은 서비스 로직에서 발생, `DispatcherServlet`이 `IOException`을 2번을 발생시켜 3번으로 알고있었다.
이 부분을 잘못 알고 있었던 것이다.

```java
[http-nio-8080-exec-10] INFO  o.e.c.n.s.NotificationService[111] - 연결이 끊어졌습니다 : 1_1725282357545

[http-nio-8080-exec-1] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet][175] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
java.io.IOException: Broken pipe

[http-nio-8080-exec-1] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet][175] - Servlet.service() for servlet [dispatcherServlet] threw exception
java.io.IOException: Broken pipe
```
 
그래서 결국 ExceptionHandler로 잡으면 2개의 IOException이 잡히는 것이다.
그럼 왜 이렇게 해도 해결을 하지 못했다고 생각했을까?
```java
@ExceptionHandler(Exception.class)
public ResponseEntity<String> handleException(Exception e) {
    log.error("Exception 예외 발생: {}", e.getMessage(), e);
    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
}
```
그 이유는 로그에 exception까지 같이 찍어서 로그에 찍힌 IOException을 IOException이 터지는 것이라 오해했던 것이다.
문제 해결~
